### PR TITLE
Start removing static page references.

### DIFF
--- a/app/controllers/policy_controller.rb
+++ b/app/controllers/policy_controller.rb
@@ -1,2 +1,0 @@
-class PolicyController < ApplicationController
-end

--- a/app/controllers/support_controller.rb
+++ b/app/controllers/support_controller.rb
@@ -1,2 +1,0 @@
-class SupportController < ApplicationController
-end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,12 +73,6 @@ Growstuff::Application.routes.draw do
 
   get 'auth/:provider/callback' => 'authentications#create'
 
-
-  get '/policy/:action' => 'policy#:action'
-
-  get '/support' => 'support#index'
-  get '/support/:action' => 'support#:action'
-
   get '/about' => 'about#index'
   get '/about/:action' => 'about#:action'
 


### PR DESCRIPTION
Fix #690 (get rid of old static support/policy/about pages)

Needs careful testing on staging.